### PR TITLE
Create generator-generic-ossf-slsa3-publish.yml

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -1,0 +1,66 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow lets you generate SLSA provenance file for your project.
+# The generation satisfies level 3 for the provenance requirements - see https://slsa.dev/spec/v0.1/requirements
+# The project is an initiative of the OpenSSF (openssf.org) and is developed at
+# https://github.com/slsa-framework/slsa-github-generator.
+# The provenance file can be verified using https://github.com/slsa-framework/slsa-verifier.
+# For more information about SLSA and how it improves the supply-chain, visit slsa.dev.
+
+name: SLSA generic generator
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      digests: ${{ steps.hash.outputs.digests }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ========================================================
+      #
+      # Step 1: Build your artifacts.
+      #
+      # ========================================================
+      - name: Build artifacts
+        run: |
+            # These are some amazing artifacts.
+            echo "artifact1" > artifact1
+            echo "artifact2" > artifact2
+
+      # ========================================================
+      #
+      # Step 2: Add a step to generate the provenance subjects
+      #         as shown below. Update the sha256 sum arguments
+      #         to include all binaries that you generate
+      #         provenance for.
+      #
+      # ========================================================
+      - name: Generate subject for provenance
+        id: hash
+        run: |
+          set -euo pipefail
+
+          # List the artifacts the provenance will refer to.
+          files=$(ls artifact*)
+          # Generate the subjects (base64 encoded).
+          echo "hashes=$(sha256sum $files | base64 -w0)" >> "${GITHUB_OUTPUT}"
+
+  provenance:
+    needs: [build]
+    permissions:
+      actions: read   # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.4.0
+    with:
+      base64-subjects: "${{ needs.build.outputs.digests }}"
+      upload-assets: true # Optional: Upload to a new release


### PR DESCRIPTION
# This workflow uses actions that are not certified by GitHub. # They are provided by a third-party and are governed by # separate terms of service, privacy policy, and support # documentation.
#
# This workflow generates a SLSA provenance file for your project, # satisfying level 3 of the provenance requirements. # See https://slsa.dev/spec/v0.1/requirements for details. #
# The generator is maintained by the OpenSSF:
# https://github.com/slsa-framework/slsa-github-generator #
# You can verify the provenance file with:
# https://github.com/slsa-framework/slsa-verifier

name: SLSA generic generator

on:
  workflow_dispatch:
  release:
    types: [created]

jobs:
  build:
    runs-on: ubuntu-latest
    outputs:
      digests: ${{ steps.generate_provenance.outputs.digests }}
    steps:

      - name: Check out source
        uses: actions/checkout@v4

      - name: Set up Python
        uses: actions/setup-python@v4
        with:
          python-version: '3.x'

      - name: Install SLSA generator
        run: |
          pip install slsa-github-generator

      - name: Build artifacts
        run: |
          # Replace these lines with your real build commands
          echo "artifact1" > artifact1

      - name: Generate SLSA provenance
        id: generate_provenance
        uses: slsa-framework/slsa-github-generator@v0.4.0
        with:
          # Commands used to build your artifacts
          build-commands: |
            echo "artifact1" > artifact1
          # List of outputs to include in provenance
          artifacts: artifact1

      - name: Verify provenance
        uses: slsa-framework/slsa-verifier@v1
        with:
          provenance-file: ./provenance.json

      - name: Upload provenance file
        uses: actions/upload-artifact@v3
        with:
          name: slsa-provenance
          path: provenance.json

      - name: Attach artifacts to release
        if: github.event_name == 'release'
        uses: ncipollo/release-action@v1
        with:
          artifacts: |
            artifact1
            provenance.json